### PR TITLE
Add method to get just the text from the gemini response

### DIFF
--- a/src/DotnetGeminiSDK.Tests/GeminiClientTests.cs
+++ b/src/DotnetGeminiSDK.Tests/GeminiClientTests.cs
@@ -18,11 +18,25 @@ namespace DotnetGeminiSDK.Tests
             _client = new GeminiClient(new GoogleGeminiConfig(), _apiRequesterMock.Object);
         }
 
+
         [Fact]
         public async Task TextPrompt_WithSingleMessage_ReturnsResponse()
         {
+            var part = new Model.Response.Part(){
+                Text = "test response text"
+            };
+            var content = new Model.Response.Content(){
+                Parts = new List<Model.Response.Part>{part}
+            };
+            var candidate = new Candidate(){
+                Content = content
+            };
+            var expectedResponse = new GeminiMessageResponse{
+                Candidates = new List<Model.Response.Candidate>{candidate}
+                };
+
             var message = "Test message";
-            var expectedResponse = new GeminiMessageResponse();
+            
             _apiRequesterMock.Setup(r => r.PostAsync<GeminiMessageResponse>(It.IsAny<string>(), It.IsAny<GeminiMessageRequest>()))
                              .ReturnsAsync(expectedResponse);
 
@@ -30,6 +44,7 @@ namespace DotnetGeminiSDK.Tests
 
             Assert.NotNull(response);
             Assert.Equal(expectedResponse, response);
+            Assert.Equal(part.Text, response.GetResponseText()[0]);
         }
 
         [Fact]

--- a/src/DotnetGeminiSDK/Model/Response/GeminiMessageResponse.cs
+++ b/src/DotnetGeminiSDK/Model/Response/GeminiMessageResponse.cs
@@ -8,6 +8,23 @@ namespace DotnetGeminiSDK.Model.Response
         [JsonProperty("candidates")] public List<Candidate> Candidates { get; set; }
 
         [JsonProperty("promptFeedback")] public PromptFeedback PromptFeedback { get; set; }
+
+
+        /// <summary>
+        /// Returns all of the response texts from the GeminiMessageResponse
+        /// </summary>
+        /// <returns>Returns a list<string> with all the response texts from the GeminiMessageResponse</returns>
+        public List<string> GetResponseText(){
+            var responseList = new List<string>();
+
+            foreach (var candidate in Candidates){
+                if (!string.IsNullOrEmpty(candidate?.Content?.Parts[0]?.Text)){
+                    responseList.Add(candidate?.Content?.Parts[0]?.Text);
+                }
+            }
+
+            return responseList;
+        }
     }
 
     public class Candidate


### PR DESCRIPTION
# Pull Request

## Description

When building a project recently that employed this SDK, I found the process of retrieving the actual text from the Gemini response a bit tedious. It's great that there is a lot of info sent in the API response, however for my use case (and I suspect a lot of other people's), really just the text is needed. This method does the heavy lifting, and just returns a list of strings (in case there was more than 1 text response).

## Type of Change

Please delete options that are not relevant.

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (correction or addition to documentation)

## Checklist

Please review the checklist before submitting the pull request:

- [X] My code follows the code style of this project.
- [X] My changes generate no new warnings or errors.
- [X] I have added tests to cover my changes, if applicable.
- [X] All new and existing tests passed.
- [X] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.

## Screenshots (if applicable)

Add screenshots to help explain your changes if they are relevant.

## Additional Context

Add any other context about the pull request here.
